### PR TITLE
support v0.1.0 delete cidr infos

### DIFF
--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -91,7 +91,7 @@ func (d *Driver) GetIP() (string, error) {
 		return "", err
 	}
 
-	return vmi.Status.Interfaces[0].IP, nil
+	return strings.Split(vmi.Status.Interfaces[0].IP, "/")[0], nil
 }
 
 func (d *Driver) GetState() (state.State, error) {


### PR DESCRIPTION
Only return a IP not with Cidr. This change should not bee breaking if kubevirt only outputs a ip.