### PR TITLE
Fix bootOrder missing in old version

### DIFF
--- a/harvester/create.go
+++ b/harvester/create.go
@@ -212,6 +212,7 @@ func (d *Driver) Disks(vmBuilder *builder.VMBuilder) (*builder.VMBuilder, error)
 			Bus:         d.DiskBus,
 			Type:        builder.DiskTypeDisk,
 			Size:        d.DiskSize,
+			BootOrder:   1,
 			HotPlugAble: false,
 		}
 		vmBuilder, err = d.addDisk(vmBuilder, &disk, 1)


### PR DESCRIPTION
Missing bootOrder causes the old UI + the new node driver cannot create ready cluster

**Related issues**
https://github.com/harvester/harvester/issues/2426