### PR TITLE
Revert the type of Driver.DiskSize to string

### DIFF
--- a/harvester/config.go
+++ b/harvester/config.go
@@ -76,7 +76,7 @@ func (d *Driver) checkConfig() error {
 		if d.ImageName == "" {
 			return errors.New("must specify harvester image name")
 		}
-		if d.DiskSize <= 0 {
+		if d.DiskSize == "0" {
 			return errors.New("must specify harvester disk size")
 		}
 	}

--- a/harvester/create.go
+++ b/harvester/create.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strconv"
 	"time"
 
 	"github.com/rancher/machine/libmachine/drivers"
@@ -207,11 +208,15 @@ func (d *Driver) Disks(vmBuilder *builder.VMBuilder) (*builder.VMBuilder, error)
 		}
 	} else {
 		// Compatible with older versions
+		diskSize, err := strconv.Atoi(d.DiskSize)
+		if err != nil {
+			return nil, err
+		}
 		disk := Disk{
 			ImageName:   d.ImageName,
 			Bus:         d.DiskBus,
 			Type:        builder.DiskTypeDisk,
-			Size:        d.DiskSize,
+			Size:        diskSize,
 			BootOrder:   1,
 			HotPlugAble: false,
 		}

--- a/harvester/flags.go
+++ b/harvester/flags.go
@@ -3,6 +3,7 @@ package harvester
 import (
 	"encoding/base64"
 	"fmt"
+	"strconv"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/mcnflag"
@@ -152,7 +153,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 
 	d.CPU = flags.Int("harvester-cpu-count")
 	d.MemorySize = fmt.Sprintf("%dGi", flags.Int("harvester-memory-size"))
-	d.DiskSize = flags.Int("harvester-disk-size")
+	d.DiskSize = strconv.Itoa(flags.Int("harvester-disk-size"))
 	d.DiskBus = flags.String("harvester-disk-bus")
 
 	d.ImageName = flags.String("harvester-image-name")

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -45,7 +45,7 @@ type Driver struct {
 
 	CPU        int
 	MemorySize string
-	DiskSize   int
+	DiskSize   string
 	DiskBus    string
 
 	ImageName string


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**Problem**
![08726b9c4bed8e4038b054f9b8e6425](https://user-images.githubusercontent.com/15064560/212857985-27e6716e-0edb-44d5-b224-17e66815ee3c.png)

**reproduce steps:**
1. create rke2 cluster with v2.7.0 and node driver v.0.5.0
2. bump node driver to v0.6.0
3. edit rke2 cluster

old nodes of the rke2 cluster keep `Deleteing` and after a long time, show `Deleteerror`

**Solution**
type of Driver.DiskSize must keep string for compatibility

**Related issues**
https://github.com/harvester/harvester/issues/2426

Download URL: https://github.com/futuretea/docker-machine-driver-harvester/releases/download/v0.0.0-f8f2ef2/docker-machine-driver-harvester-amd64.tar.gz
