### PR TITLE
remove qemu-guest-agent auto-injection

### DIFF
--- a/harvester/cloudinit.go
+++ b/harvester/cloudinit.go
@@ -87,8 +87,6 @@ func (d *Driver) mergeCloudInit() (string, string, error) {
 		networkData string
 	)
 	// userData
-	// need qemu guest agent to get ip
-	userData = userDataAddQemuGuestAgent
 	if d.SSHPassword != "" {
 		userData += fmt.Sprintf(userDataPasswordTemplate, d.SSHUser, d.SSHPassword)
 	}

--- a/harvester/cloudinit.go
+++ b/harvester/cloudinit.go
@@ -3,6 +3,7 @@ package harvester
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/harvester/harvester/pkg/builder"
@@ -13,6 +14,8 @@ import (
 
 const (
 	userDataHeader = `#cloud-config
+`
+	userDataHeaderTemplateJinja = `## template: jinja
 `
 	userDataAddQemuGuestAgent = `
 package_update: true
@@ -116,6 +119,9 @@ func (d *Driver) mergeCloudInit() (string, string, error) {
 		userData = string(userDataByte)
 	}
 	userData = userDataHeader + userData
+	if strings.HasPrefix(d.UserData, userDataHeaderTemplateJinja) {
+		userData = userDataHeaderTemplateJinja + userData
+	}
 	// networkData
 	if d.NetworkData != "" {
 		networkData = d.NetworkData


### PR DESCRIPTION
- remove qemu-guest-agent auto-injection
- add template jinjaa support (refer to https://github.com/harvester/harvester/issues/2342)

**Related issues**
https://github.com/harvester/harvester/issues/3392

**Test Plan**

1. Setup a v2.7-head Rancher

On Rancher `Cluster Management` > `Drivers` > `Node Drivers` UI
2. change Harvester node driver 's `build-in` to false via view-API
![image](https://user-images.githubusercontent.com/15064560/167762217-ce5f4353-8c49-464d-aef7-ce1deb0f41ee.png)

3.  edit Harvester node driver 
change Download URL to "https://github.com/futuretea/docker-machine-driver-harvester/releases/download/v0.0.0-2c27768/docker-machine-driver-harvester-amd64.tar.gz" and
checksum to `a61220d014f2821f8ced112a1bd15c1c79059c531bf4bb4f4c95823ad777e5b3`

4. Import a Harvester cluster to Rancher
5. Create RKE2 cluster with userdata
```yaml
## template: jinja
#cloud-config
write_files:
  - content: |
      #!/bin/bash
      vmName=$1
      echo "VM Name is: $vmName" > /home/cloudinitscript.log
    path: /home/exec_initscript.sh
    permissions: '0755'
package_update: true
packages:
  - qemu-guest-agent
  - iptables
runcmd:
  - - systemctl
    - enable
    - '--now'
    - qemu-guest-agent.service
  - - echo
    - "{{ ds.meta_data.local_hostname }}"
  - - /home/exec_initscript.sh
    - "{{ ds.meta_data.local_hostname }}"
```