### PR TITLE
Bump dapper version to v0.6.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper ci
   volumes:


### PR DESCRIPTION
fix ci https://drone-publish.rancher.io/harvester/docker-machine-driver-harvester/33/1/2