### PR TITLE
Change cloudinit merge order

### DIFF
--- a/harvester/cloudinit.go
+++ b/harvester/cloudinit.go
@@ -100,19 +100,19 @@ func (d *Driver) mergeCloudInit() (string, string, error) {
 			userData += fmt.Sprintf(userDataSSHKeyTemplate, d.SSHPublicKey)
 		}
 	}
+	if d.UserData != "" {
+		userDataByte, err := mergeYaml([]byte(userData), []byte(d.UserData))
+		if err != nil {
+			return "", "", err
+		}
+		userData = string(userDataByte)
+	}
 	if d.CloudConfig != "" {
 		cloudConfigContent, err := ioutil.ReadFile(d.CloudConfig)
 		if err != nil {
 			return "", "", err
 		}
 		userDataByte, err := mergeYaml([]byte(userData), cloudConfigContent)
-		if err != nil {
-			return "", "", err
-		}
-		userData = string(userDataByte)
-	}
-	if d.UserData != "" {
-		userDataByte, err := mergeYaml([]byte(userData), []byte(d.UserData))
 		if err != nil {
 			return "", "", err
 		}

--- a/harvester/cloudinit_test.go
+++ b/harvester/cloudinit_test.go
@@ -1,0 +1,89 @@
+package harvester
+
+import (
+	"testing"
+)
+
+const (
+	testCloudInitFilePath = "testdata/cloudinit_rke2.yaml"
+)
+
+func TestDriver_mergeCloudInitUserData(t *testing.T) {
+	type fields struct {
+		CloudConfig string
+		UserData    string
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		wantUserData string
+		wantErr      bool
+	}{
+		{
+			name: "empty cloud config and user data",
+			fields: fields{
+				CloudConfig: "",
+				UserData:    "",
+			},
+			wantUserData: `#cloud-config
+`,
+			wantErr: false,
+		},
+		{
+			name: "rke2 cloud config and empty user data",
+			fields: fields{
+				CloudConfig: testCloudInitFilePath,
+				UserData:    "",
+			},
+			wantUserData: `#cloud-config
+runcmd:
+- sh /usr/local/custom_script/install.sh
+`,
+			wantErr: false,
+		},
+		{
+			name: "rke2 cloud config and user data",
+			fields: fields{
+				CloudConfig: testCloudInitFilePath,
+				UserData: `#cloud-config
+package_update: true
+packages:
+- qemu-guest-agent
+runcmd:
+- - systemctl
+- - enable
+- - --now
+- - qemu-guest-agent.service
+`,
+			},
+			wantUserData: `#cloud-config
+package_update: true
+packages:
+- qemu-guest-agent
+runcmd:
+- - systemctl
+- - enable
+- - --now
+- - qemu-guest-agent.service
+- sh /usr/local/custom_script/install.sh
+`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Driver{
+				CloudConfig: tt.fields.CloudConfig,
+				UserData:    tt.fields.UserData,
+			}
+			got, _, err := d.mergeCloudInit()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mergeCloudInit() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.wantUserData {
+				t.Errorf("mergeCloudInit() got = %v, want %v", got, tt.wantUserData)
+			}
+		})
+	}
+}

--- a/harvester/testdata/cloudinit_rke2.yaml
+++ b/harvester/testdata/cloudinit_rke2.yaml
@@ -1,0 +1,2 @@
+runcmd:
+- sh /usr/local/custom_script/install.sh


### PR DESCRIPTION
change the merge order
merge d.CloudConfig in the end

**Related issues**
https://github.com/harvester/harvester/issues/3855

**Test plan**
1. Go to the Rancher UI and click `Cluster Management` > `Drivers` > `Node Drivers`. In the `Node Drivers` list, find ` Harvester` and then click `⋮`  > `View in API`.
2. Click `Edit`.
3. Uncheck the `builtin` checkbox.
4. Change the `*url` to `https://github.com/futuretea/docker-machine-driver-harvester/releases/download/v0.0.0-ce551fc/docker-machine-driver-harvester-amd64.tar.gz`.
5. Change the `checksum` to `33ab8006ed03c1eaf77d1d0dbbb7c8bd3f7d2ceb60fadc3fbcea237faf88f6dc`.
6. Click `Show Request` > `Send Request`.
7. Click `Reload` util the value of `status.appliedChecksum` and `status.appliedURL` change to the value we set.
8. Use Harvester node driver to provision a RKE2 cluster
9. Check the created VM's cloud config userdata


In the runcmd section, the injected part `sh /usr/local/custom_script/install.sh ` was injected at beginning.