### PR TITLE
additional labels / affinity rules calculated by machine driver

### DIFF
--- a/harvester/create.go
+++ b/harvester/create.go
@@ -52,7 +52,8 @@ func (d *Driver) Create() error {
 		//we can reverse split this to identify unique machinesets name, to label nodes
 		//with this unique machine set. This can then be used for populating affinity rules
 		machineSetSplit := strings.Split(d.MachineName, "-")
-		machineSetName := strings.Join(machineSetSplit[:len(machineSetSplit)-1], "-")
+		machineSetSplit = append([]string{d.VMNamespace}, machineSetSplit...)
+		machineSetName := strings.Join(machineSetSplit[:len(machineSetSplit)-2], "-")
 		vmBuilder = vmBuilder.Labels(map[string]string{poolNameLabelKey: machineSetName})
 		addtionalPodAffinityTerm := corev1.PodAffinityTerm{
 			LabelSelector: &metav1.LabelSelector{


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/4588

When a VM set is launched from the Harvester UI, and anti-affinity rules are specified, then Harvester enhances the VM definitions to add additional labels in `vm.spec.metadata.labels`

```
      labels:
        harvesterhci.io/vmName: ubuntu-vmset-01
        harvesterhci.io/vmNamePrefix: ubuntu-vmset
```

The additional `vmNamePrefix` label is used during defining `podAffinity` or `podAntiAffinity`

```
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  harvesterhci.io/vmNamePrefix: ubuntu-vmset
              topologyKey: kubernetes.io/hostname
            weight: 1
          requiredDuringSchedulingIgnoredDuringExecution:
          - topologyKey: topology.kubernetes.io/zone
      domain:
```

Rancher machine driver does not pass this information when provisioning nodes.

We can however evaluate the rancher `machineset` name from the VM name as it follows the convention `clusterName-poolName-generatedID`

The PR leverages this logic to add an additional label to VM's 
```
  labels:
    harvesterhci.io/creator: docker-machine-driver-harvester
    harvesterhci.io/machineSetName: affinity2-pool1-0d403cc4
    harvesterhci.io/vmName: affinity2-pool1-0d403cc4-4qzs7
```

This additional label can then be used to generated more refined anti affinity rules

```
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  harvesterhci.io/machineSetName: affinity2-pool1-0d403cc4
              topologyKey: kubernetes.io/hostname
            weight: 1
          requiredDuringSchedulingIgnoredDuringExecution:
          - topologyKey: topology.kubernetes.io/zone
```

