### PR TITLE
support for vgpu devices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200331171230-d50e42f2b669
 	github.com/rancher/machine v0.15.0-rancher99
 	github.com/rancher/wrangler v1.1.0
+	github.com/stretchr/testify v1.8.2
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v12.0.0+incompatible
@@ -119,6 +120,7 @@ require (
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.62.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -866,6 +866,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.3-0.20181224173747-660f15d67dbb/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -876,6 +877,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=

--- a/harvester/config.go
+++ b/harvester/config.go
@@ -59,7 +59,7 @@ type NetworkInterface struct {
 }
 
 type VGPUInfo struct {
-	VGPURequests []VGPURequest `json:"vGPU"`
+	VGPURequests []VGPURequest `json:"vGPURequests"`
 }
 
 type VGPURequest struct {

--- a/harvester/config.go
+++ b/harvester/config.go
@@ -58,6 +58,15 @@ type NetworkInterface struct {
 	Type  string `json:"type"`
 }
 
+type VGPUInfo struct {
+	VGPURequests []VGPURequest `json:"vGPU"`
+}
+
+type VGPURequest struct {
+	Name       string `json:"name"`
+	DeviceName string `json:"deviceName"`
+}
+
 func (d *Driver) checkConfig() error {
 	if d.KeyPairName != "" && d.SSHPrivateKeyPath == "" {
 		return errors.New("must specify the ssh private key path of the harvester key pair")
@@ -244,4 +253,13 @@ func mustGetSection(m map[string]interface{}, k string) (interface{}, error) {
 		return nil, fmt.Errorf("missing section: %s", k)
 	}
 	return section, nil
+}
+
+func parseVGPUInfo(vGPUInfo string) (*VGPUInfo, error) {
+	v := &VGPUInfo{}
+	err := json.Unmarshal([]byte(vGPUInfo), v)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling vgpuInfo string")
+	}
+	return v, nil
 }

--- a/harvester/config_test.go
+++ b/harvester/config_test.go
@@ -264,7 +264,7 @@ func Test_parseVGPUInfo(t *testing.T) {
 			},
 		},
 	}
-	vgpuInfoString := `{"vGPU":[{"name":"","deviceName":"nvidia.com/NVIDIA_A2-2Q"},{"name":"","deviceName":"nvidia.com/NVIDIA_A2-1Q"}]}`
+	vgpuInfoString := `{"vGPURequests":[{"name":"","deviceName":"nvidia.com/NVIDIA_A2-2Q"},{"name":"","deviceName":"nvidia.com/NVIDIA_A2-1Q"}]}`
 	assert := require.New(t)
 	v, err := parseVGPUInfo(vgpuInfoString)
 	assert.NoError(err)

--- a/harvester/config_test.go
+++ b/harvester/config_test.go
@@ -2,6 +2,8 @@ package harvester
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckNetworkData(t *testing.T) {
@@ -249,4 +251,23 @@ network:
 			}
 		})
 	}
+}
+
+func Test_parseVGPUInfo(t *testing.T) {
+	vObj := &VGPUInfo{
+		VGPURequests: []VGPURequest{
+			{
+				DeviceName: "nvidia.com/NVIDIA_A2-2Q",
+			},
+			{
+				DeviceName: "nvidia.com/NVIDIA_A2-1Q",
+			},
+		},
+	}
+	vgpuInfoString := `{"vGPU":[{"name":"","deviceName":"nvidia.com/NVIDIA_A2-2Q"},{"name":"","deviceName":"nvidia.com/NVIDIA_A2-1Q"}]}`
+	assert := require.New(t)
+	v, err := parseVGPUInfo(vgpuInfoString)
+	assert.NoError(err)
+	assert.Equal(v, vObj, "expected request to match predefined object")
+
 }

--- a/harvester/config_test.go
+++ b/harvester/config_test.go
@@ -269,5 +269,4 @@ func Test_parseVGPUInfo(t *testing.T) {
 	v, err := parseVGPUInfo(vgpuInfoString)
 	assert.NoError(err)
 	assert.Equal(v, vObj, "expected request to match predefined object")
-
 }

--- a/harvester/create.go
+++ b/harvester/create.go
@@ -82,6 +82,9 @@ func (d *Driver) Create() error {
 	}
 	// network interfaces
 	vmBuilder = d.NetworkInterfaces(vmBuilder)
+
+	// add vGPU info
+	vmBuilder = d.ConfigureVGPU(vmBuilder)
 	// disks
 	vmBuilder, err = d.Disks(vmBuilder)
 	if err != nil {
@@ -286,6 +289,19 @@ func (d *Driver) NetworkInterfaces(vmBuilder *builder.VMBuilder) *builder.VMBuil
 			Type:        builder.NetworkInterfaceTypeBridge,
 		}
 		d.AddNetworkInterface(vmBuilder, &networkInterface, 0)
+	}
+	return vmBuilder
+}
+
+// ConfigureVGPU will configure vmBuilder with vGPUInfo passed through driver
+func (d *Driver) ConfigureVGPU(vmBuilder *builder.VMBuilder) *builder.VMBuilder {
+	if d.VGPUInfo == nil {
+		return vmBuilder
+	}
+
+	for _, v := range d.VGPUInfo.VGPURequests {
+		// pass name, deviceName, tags(if any), and vGPUOptions if any
+		vmBuilder = vmBuilder.GPU(v.Name, v.DeviceName, "", nil)
 	}
 	return vmBuilder
 }

--- a/harvester/flags.go
+++ b/harvester/flags.go
@@ -150,6 +150,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "harvester-enable-secure-boot",
 			Usage:  "enable vm secure boot, only works when enable efi",
 		},
+		mcnflag.StringFlag{
+			EnvVar: "HARVESTER_VGPU_INFO",
+			Name:   "harvester-vgpu-info",
+			Usage:  "harvester-vgpu-info",
+		},
 	}
 }
 
@@ -210,6 +215,14 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 
 	d.SetSwarmConfigFromFlags(flags)
 
+	vGPUInfoString := flags.String("harvester-vgpu-info")
+	if vGPUInfoString != "" {
+		vGPUInfo, err := parseVGPUInfo(vGPUInfoString)
+		if err != nil {
+			return err
+		}
+		d.VGPUInfo = vGPUInfo
+	}
 	return d.checkConfig()
 }
 

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -72,6 +72,7 @@ type Driver struct {
 
 	EnableEFI        bool
 	EnableSecureBoot bool
+	VGPUInfo         *VGPUInfo
 }
 
 func NewDriver(hostName, storePath string) *Driver {


### PR DESCRIPTION
PR introduces a new flag `harvester-vgpu-info` and associated backend changes to allow passing multiple vGPU's to nodes during downstream cluster provisioning. 

related to: https://github.com/harvester/harvester/issues/2764