### PR TITLE
fix: enable secure boot

### DIFF
--- a/harvester/create.go
+++ b/harvester/create.go
@@ -99,7 +99,11 @@ func (d *Driver) Create() error {
 	vm.APIVersion = kubevirtv1.GroupVersion.String()
 
 	if d.EnableEFI {
+		if vm.Spec.Template.Spec.Domain.Features == nil {
+			vm.Spec.Template.Spec.Domain.Features = &kubevirtv1.Features{}
+		}
 		v := d.EnableSecureBoot
+		vm.Spec.Template.Spec.Domain.Features.SMM = &kubevirtv1.FeatureState{Enabled: &v}
 		vm.Spec.Template.Spec.Domain.Firmware = &kubevirtv1.Firmware{Bootloader: &kubevirtv1.Bootloader{EFI: &kubevirtv1.EFI{SecureBoot: &v}}}
 	}
 	createdVM, err := d.createVM(vm)


### PR DESCRIPTION
issue: https://github.com/harvester/harvester/issues/4777

## Test paln

### Setup

1. Clone rancher2.
```
git clone https://github.com/FrankYang0529/terraform-provider-rancher2 -b HARV-4777
```
2. Build binary.
```
CGO_ENABLED=0 go build -ldflags="-w -s -X main.VERSION=test -extldflags -static" -o bin/terraform-provider-rancher2
```
3. Move the binary to terraform folder.
```
mkdir -p ~/.terraform.d/plugins/registry.terraform.io/rancher/rancher2/0.0.0-dev/linux_amd64
cp bin/terraform-provider-rancher2 ~/.terraform.d/plugins/registry.terraform.io/rancher/rancher2/0.0.0-dev/linux_amd64/terraform-provider-rancher2_v0.0.0-dev
```
4. Create an image and vlan in harvester.
5. Create a folder to put guest cluster terraform.
```tf
# provider.tf
terraform {
  required_providers {
    rancher2 = {
      source  = "rancher/rancher2"
      version = "0.0.0-dev"
    }
  }
}

# Configure the Rancher2 provider to admin
provider "rancher2" {
  api_url    = "<rancher api url>"
  access_key = "<rancher access key>"
  secret_key = "<rancher secret key>"
  insecure   = true
}
```

### Case 1: enable_efi = true

1. Put guest cluster terraform to the folder.
```tf
# main.tf
# Get imported harvester cluster info
data "rancher2_cluster_v2" "harv" {
  name = "<harveste cluster name in rancher>"
}

# Create a new Cloud Credential for an imported Harvester cluster
resource "rancher2_cloud_credential" "harv-cred" {
  name = "harv-cred"
  harvester_credential_config {
    cluster_id = data.rancher2_cluster_v2.harv.cluster_v1_id
    cluster_type = "imported"
    kubeconfig_content = data.rancher2_cluster_v2.harv.kube_config
  }
}

# Create a new rancher2 machine config v2 using harvester node_driver
resource "rancher2_machine_config_v2" "rke2-machine" {
  generate_name = "rke2-machine"
  harvester_config {
    vm_namespace = "default"
    cpu_count = "2"
    memory_size = "4"
    disk_info = <<EOF
    {
        "disks": [{
            "imageName": "<image-namespace>/<image-name>",
            "size": 20,
            "bootOrder": 1
        }]
    }
    EOF
    network_info = <<EOF
    {
        "interfaces": [{
            "networkName": "<network-namespace>/<network-name>"
        }]
    }
    EOF
    ssh_user = "ubuntu"
    user_data = <<EOF
    package_update: true
    packages:
      - qemu-guest-agent
      - iptables
    runcmd:
      - - systemctl
        - enable
        - '--now'
        - qemu-guest-agent.service
    password: test
    chpasswd:
      expire: false
    ssh_pwauth: true
    EOF
    enable_efi = true
  }
}

resource "rancher2_cluster_v2" "rke2-1" {
  name = "rke2-1"
  kubernetes_version = "v1.26.11+rke2r1"
  rke_config {
    machine_pools {
      name = "pool1"
      cloud_credential_secret_name = rancher2_cloud_credential.harv-cred.id
      control_plane_role = true
      etcd_role = true
      worker_role = true
      quantity = 1
      machine_config {
        kind = rancher2_machine_config_v2.rke2-machine.kind
        name = rancher2_machine_config_v2.rke2-machine.name
      }
    }
  }
}
```
2. Run `terraform init` and `terraform apply`.
3. Check whether VM in harvester has efi.
```yaml
        firmware:
          bootloader:
            efi:
              secureBoot: false
```
4. Cleanup.
```
terraform destroy
```

### Case 2: enable_efi = true & enable_secure_boot = true
1. Add `enable_secure_boot = true` to main.tf.
2. Run `terraform init` and `terraform apply`.
3. Check whether VM in harvester has smm, efi, and secure boot.
Ref: https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#biosuefi
```yaml
        features:
          smm:
            enables: true  
        firmware:
          bootloader:
            efi:
              secureBoot: true
```
5. Cleanup.
```
terraform destroy
```

### Case 3: enable_efi = false & enable_secure_boot = false
1. Modify `enable_efi = false` and `enable_secure_boot = false` in main.tf.
2. Run `terraform init` and `terraform apply`.
3. Check there is no efi in the VM.
4. Cleanup.
```
terraform destroy
```
