### PR TITLE
fix: get storage class name from vmimage status

### DIFF
--- a/harvester/create.go
+++ b/harvester/create.go
@@ -225,8 +225,12 @@ func (d *Driver) addDisk(vmBuilder *builder.VMBuilder, disk *Disk, diskIndex int
 		if err != nil {
 			return nil, err
 		}
+		vmimage, err := d.client.HarvesterClient.HarvesterhciV1beta1().VirtualMachineImages(imageNamespace).Get(d.ctx, imageName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
 		imageID = fmt.Sprintf("%s/%s", imageNamespace, imageName)
-		disk.StorageClassName = builder.BuildImageStorageClassName("", imageName)
+		disk.StorageClassName = vmimage.Status.StorageClassName
 	}
 	pvcOption := &builder.PersistentVolumeClaimOption{
 		ImageID:          imageID,


### PR DESCRIPTION
issue: https://github.com/harvester/harvester/issues/5165

## Test paln

1. Start a Harvester cluster and Rancher.
2. Run `make` to build new binaries.
3. In Rancher, run `kubectl edit nodedriver harvester`. Set `active: false`, `builtin: false` and remove checksum.
4. Use a server to provide binaries like
```
cd dist/artifacts
python -m http.server
```
5. In Rancher, run `kubectl edit nodedriver harvester`. Set `active: true` and `url: http://<your ip>:8000/docker-machine-driver-harvester-amd64.tar.gz`.
6. Make sure harvester node driver is ready again.
7. Setup VMImage ane Network in Harvester.
8. Create a guest cluster without error.