### PR TITLE
Add cpu_pinning and isolate_emulator_thread option

### DIFF
--- a/harvester/create.go
+++ b/harvester/create.go
@@ -106,6 +106,10 @@ func (d *Driver) Create() error {
 		vm.Spec.Template.Spec.Domain.Features.SMM = &kubevirtv1.FeatureState{Enabled: &v}
 		vm.Spec.Template.Spec.Domain.Firmware = &kubevirtv1.Firmware{Bootloader: &kubevirtv1.Bootloader{EFI: &kubevirtv1.EFI{SecureBoot: &v}}}
 	}
+
+	vm.Spec.Template.Spec.Domain.CPU.DedicatedCPUPlacement = d.CPUPinning
+	vm.Spec.Template.Spec.Domain.CPU.IsolateEmulatorThread = d.IsolateEmulatorThread
+
 	createdVM, err := d.createVM(vm)
 	if err != nil {
 		return err

--- a/harvester/flags.go
+++ b/harvester/flags.go
@@ -161,12 +161,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.BoolFlag{
 			EnvVar: "HARVESTER_CPU_PINNING",
 			Name:   "harvester-cpu-pinning",
-			Usage:  "enable vm cpu pinning, make sure the the harvester cluster enable cpu manager in at least one node",
+			Usage:  "enable vm cpu pinning, please ensure the harvester cluster has cpu manager enabled in at least one node",
 		},
 		mcnflag.BoolFlag{
 			EnvVar: "HARVESTER_ISOLATE_EMULATOR_THREAD",
 			Name:   "harvester-isolate-emulator-thread",
-			Usage:  "enable vm isolatate emulator thread, note that enabling this feature will acquire one more cpu",
+			Usage:  "enable vm isolatated emulator thread",
 		},
 	}
 }

--- a/harvester/flags.go
+++ b/harvester/flags.go
@@ -158,6 +158,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "harvester-vgpu-info",
 			Usage:  "harvester-vgpu-info",
 		},
+		mcnflag.BoolFlag{
+			EnvVar: "HARVESTER_CPU_PINNING",
+			Name:   "harvester-cpu-pinning",
+			Usage:  "enable vm cpu pinning, make sure the the harvester cluster enable cpu manager in at least one node",
+		},
+		mcnflag.BoolFlag{
+			EnvVar: "HARVESTER_ISOLATE_EMULATOR_THREAD",
+			Name:   "harvester-isolate-emulator-thread",
+			Usage:  "enable vm isolatate emulator thread, note that enabling this feature will acquire one more cpu",
+		},
 	}
 }
 
@@ -250,6 +260,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		}
 		d.VGPUInfo = vGPUInfo
 	}
+
+	d.CPUPinning = flags.Bool("harvester-cpu-pinning")
+	d.IsolateEmulatorThread = flags.Bool("harvester-isolate-emulator-thread")
+
 	return d.checkConfig()
 }
 

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -73,6 +73,9 @@ type Driver struct {
 	EnableEFI        bool
 	EnableSecureBoot bool
 	VGPUInfo         *VGPUInfo
+
+	CPUPinning            bool
+	IsolateEmulatorThread bool
 }
 
 func NewDriver(hostName, storePath string) *Driver {


### PR DESCRIPTION
related to https://github.com/harvester/harvester/issues/6551, as title, add cpu_pinning and isolate_emulator_thread option.

# Test Plan
## Prerequisite
- rancher 2.9.1 (docker image)
- harvester single node (v1.4.0-rc, would be better to have 12CPUs as we will create VM with 8cpus in test plan)
  - `> 8 CPUs` and `> 12GB mem`
  - please **_enable cpu manager_**
## Test steps
1. Build docker-machine-driver-harvester with this patch(i.e. PR)
2. Import harvester cluster to rancher (i.e. `cluster-registration-url`)
3. Go to rancher UI, deactivate harvester node driver
4. Copy the binary built in step 1. to path `/opt/drivers/management-state/bin` in rancher container
    ```sh
    docker cp docker-machine-driver-harvester <rancher_container_id>:/opt/drivers/management-state/bin/docker-machine-driver-harvester
    ```
5. In rancher container, delete harvester dynamic schema 
   ```sh
   kubectl delete dynamicschemas.management.cattle.io/harvesterconfig
   ```
6. Go to rancher UI, activate harvester node driver
7. In rancher container, apply the following yaml files to deploy rke2 guest cluster to harvester. (make sure you fill in all fields start with `<YOUR_...` in the yaml examples.)
   - harvesterconfig.yaml
   ```yaml
    apiVersion: rke-machine-config.cattle.io/v1
    cpuCount: "8"
    cpuPinning: true
    diskInfo: '{"disks":[{"imageName":"default/<YOUR_IMAGE_UNDER_DEFAULT_NS>","bootOrder":1,"size":40}]}'
    isolateEmulatorThread: true
    kind: HarvesterConfig
    memorySize: "12"
    metadata:
      name: test
      namespace: fleet-default
    networkInfo: '{"interfaces":[{"networkName":"default/<YOUR_VM_NERWORK_UNDER_DEFAULT_NS>","macAddress":""}]}'
    sshPort: "22"
    sshUser: ubuntu
    userData: I2Nsb3VkLWNvbmZpZwpwYWNrYWdlX3VwZGF0ZTogdHJ1ZQpwYWNrYWdlczoKICAtIHFlbXUtZ3Vlc3QtYWdlbnQKcnVuY21kOgogIC0gLSBzeXN0ZW1jdGwKICAgIC0gZW5hYmxlCiAgICAtICctLW5vdycKICAgIC0gcWVtdS1ndWVzdC1hZ2VudC5zZXJ2aWNlCg==
    vmNamespace: default
   ```
   - cluster.yaml
   ```yaml
   apiVersion: provisioning.cattle.io/v1
    kind: Cluster
    metadata:
      name: foobar
      namespace: fleet-default
    spec:
      cloudCredentialSecretName: cattle-global-data:<YOUR_CLOUD_CREDENTIAL_SECRET_NAME>
      kubernetesVersion: v1.30.5+rke2r1
      rkeConfig:
        etcd:
          disableSnapshots: false
          snapshotRetention: 5
          snapshotScheduleCron: 0 */5 * * *
        machineGlobalConfig:
          cni: calico
          disable-kube-proxy: false
          etcd-expose-metrics: false
        machinePools:
          - name: pool1
            etcdRole: true
            controlPlaneRole: true
            workerRole: true
            quantity: 1
            unhealthyNodeTimeout: 0m
            machineConfigRef:
              kind: HarvesterConfig
              name: test
            drainBeforeDelete: true
            labels: {}
        machineSelectorConfig:
          - config:
              cloud-provider-name: harvester
              protect-kernel-defaults: false
        upgradeStrategy:
          controlPlaneConcurrency: '1'
          controlPlaneDrainOptions:
            deleteEmptyDirData: true
            disableEviction: false
            enabled: false
            force: false
            gracePeriod: -1
            ignoreDaemonSets: true
            skipWaitForDeleteTimeoutSeconds: 0
            timeout: 120
          workerConcurrency: '1'
          workerDrainOptions:
            deleteEmptyDirData: true
            disableEviction: false
            enabled: false
            force: false
            gracePeriod: -1
            ignoreDaemonSets: true
            skipWaitForDeleteTimeoutSeconds: 0
            timeout: 120
   ```
8. Go to harvester UI, navigate to Virtual Machines page, check the vm have the following attributes
   ```yaml
    dedicatedCpuPlacement: true
    isolateEmulatorThread: true
   ```
   ![image](https://github.com/user-attachments/assets/128cb6fa-931f-41cd-88cb-f31ad79ec8d8)
