### PR TITLE
Add cluster information to the Harvester VMs of Rancher guest cluster

### DIFF
--- a/harvester/create.go
+++ b/harvester/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/machine/libmachine/state"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
@@ -25,6 +26,7 @@ const (
 	diskNamePrefix      = "disk"
 	interfaceNamePrefix = "nic"
 	poolNameLabelKey    = "harvesterhci.io/machineSetName"
+	clusterNameLabelKey = "cluster.kubernetes.io/name"
 )
 
 func (d *Driver) Create() error {
@@ -41,6 +43,12 @@ func (d *Driver) Create() error {
 		Namespace(d.VMNamespace).Name(d.MachineName).CPU(d.CPU).Memory(d.MemorySize).
 		CloudInitDisk(builder.CloudInitDiskName, builder.DiskBusVirtio, false, 0, *cloudInitSource).
 		EvictionStrategy(true).RunStrategy(kubevirtv1.RunStrategyRerunOnFailure)
+
+	if d.ClusterName != "" {
+		vmBuilder.Labels(labels.Set{
+			clusterNameLabelKey: d.ClusterName,
+		})
+	}
 
 	// affinity
 	var affinity *corev1.Affinity

--- a/harvester/create.go
+++ b/harvester/create.go
@@ -26,7 +26,7 @@ const (
 	diskNamePrefix      = "disk"
 	interfaceNamePrefix = "nic"
 	poolNameLabelKey    = "harvesterhci.io/machineSetName"
-	clusterNameLabelKey = "cluster.kubernetes.io/name"
+	clusterNameLabelKey = "guestcluster.harvesterhci.io/name"
 )
 
 func (d *Driver) Create() error {

--- a/harvester/flags.go
+++ b/harvester/flags.go
@@ -39,6 +39,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "harvester cluster id",
 		},
 		mcnflag.StringFlag{
+			EnvVar: "HARVESTER_CLUSTER_NAME",
+			Name:   "harvester-cluster-name",
+			Usage:  "harvester cluster name",
+		},
+		mcnflag.StringFlag{
 			EnvVar: "HARVESTER_VM_NAMESPACE",
 			Name:   "harvester-vm-namespace",
 			Usage:  "harvester vm namespace",
@@ -207,6 +212,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.VMAffinity = stringSupportBase64(flags.String("harvester-vm-affinity"))
 	d.ClusterType = flags.String("harvester-cluster-type")
 	d.ClusterID = flags.String("harvester-cluster-id")
+	d.ClusterName = flags.String("harvester-cluster-name")
 
 	d.CPU = flags.Int("harvester-cpu-count")
 	d.MemorySize = fmt.Sprintf("%dGi", flags.Int("harvester-memory-size"))

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -42,6 +42,7 @@ type Driver struct {
 	VMAffinity  string
 	ClusterType string
 	ClusterID   string
+	ClusterName string
 
 	ServerVersion string
 


### PR DESCRIPTION
Add a new flag called `harvester-cluster-name` (the environment variable is named `HARVESTER_CLUSTER_NAME`) and set the label `cluster.kubernetes.io/name` to the VM if the cluster name is set.

Related to:
- https://github.com/harvester/harvester/issues/4089
- https://github.com/rancher/rancher/issues/49132
- https://github.com/rancher/rancher/pull/48010

### Test steps

1. Create a harvester cluster and Rancher v2.11.0-alpha7.
2. Change docker-machine-driver-harvester to this branch.
3. Create a guest cluster and check there is `guestcluster.harvesterhci.io/name` label on the VM.