### PR TITLE
fix: ensure the machineset label value is valid per K8s convention

### DIFF
--- a/harvester/create.go
+++ b/harvester/create.go
@@ -53,9 +53,12 @@ func (d *Driver) Create() error {
 		//with this unique machine set. This can then be used for populating affinity rules
 		machineSetSplit := strings.Split(d.MachineName, "-")
 		machineSetSplit = append([]string{d.VMNamespace}, machineSetSplit...)
-		machineSetName := strings.Join(machineSetSplit[:len(machineSetSplit)-2], "-")
+		machineSetName, err := formatLabelValue(strings.Join(machineSetSplit[:len(machineSetSplit)-2], "-"))
+		if err != nil {
+			return err
+		}
 		vmBuilder = vmBuilder.Labels(map[string]string{poolNameLabelKey: machineSetName})
-		addtionalPodAffinityTerm := corev1.PodAffinityTerm{
+		additionalPodAffinityTerm := corev1.PodAffinityTerm{
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					poolNameLabelKey: machineSetName,
@@ -65,7 +68,7 @@ func (d *Driver) Create() error {
 		}
 		additionalWeightPodAffinity := corev1.WeightedPodAffinityTerm{
 			Weight:          1,
-			PodAffinityTerm: addtionalPodAffinityTerm,
+			PodAffinityTerm: additionalPodAffinityTerm,
 		}
 		if affinity.PodAffinity != nil {
 			affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution, additionalWeightPodAffinity)

--- a/harvester/labels.go
+++ b/harvester/labels.go
@@ -1,0 +1,32 @@
+package harvester
+
+import (
+	"encoding/base64"
+	"fmt"
+	"hash/fnv"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// formatLabelValue returns v if it meets the standards for a Kubernetes
+// label value. Otherwise, it returns a hash which meets the requirements.
+// ref: https://github.com/kubernetes-sigs/cluster-api/blob/010af7f92f98ead971742d347d258a8786d5d57c/util/labels/format/helpers.go
+func formatLabelValue(v string) (string, error) {
+	// a valid Kubernetes label value must:
+	// - be less than 64 characters long.
+	// - be an empty string OR consist of alphanumeric characters, '-', '_' or '.'.
+	// - start and end with an alphanumeric character
+	if len(validation.IsValidLabelValue(v)) == 0 {
+		return v, nil
+	}
+
+	hasher := fnv.New32a()
+	if _, err := hasher.Write([]byte(v)); err != nil {
+		return "", err
+	}
+
+	// use base64 URL encoding to avoid special characters like '/' in the generated
+	// hash
+	return fmt.Sprintf("hash_%s_z",
+		base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))), nil
+}

--- a/harvester/labels_test.go
+++ b/harvester/labels_test.go
@@ -1,0 +1,38 @@
+package harvester
+
+import "testing"
+
+func TestFormatLabelValue(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		labelValue string
+		expected   string
+	}{
+		{
+			desc:       "return empty string if label value is empty",
+			labelValue: "",
+			expected:   "",
+		},
+		{
+			desc:       "return label value unchanged if it's less than 63 characters",
+			labelValue: "machineSetName",
+			expected:   "machineSetName",
+		},
+		{
+			desc:       "return hashed label value if more than 63 characters",
+			labelValue: "machineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetName",
+			expected:   "hash_FR_ghQ_z",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(*testing.T) {
+			actual, err := formatLabelValue(tc.labelValue)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.expected != actual {
+				t.Errorf("test case failed: %s. expected %s, got %s", tc.desc, tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When user defined custom affinity/anti-affinity rules for VMs, additional `preferred` affinity/anti-affinity rules are added to ensure the `virt-launcher` pods don't land on the same node (by keying the rules off the node's hostname). Currently, there are no checks to ensure the generated label value in these rules adhered to the Kubernetes' labeling convention.

This PR uses the same approach as CAPI to [format and hash the label value](https://github.com/kubernetes-sigs/cluster-api/blob/010af7f92f98ead971742d347d258a8786d5d57c/util/labels/format/helpers.go). Since the machineset label value is only used to establish pod affinity, the actual (hashed or not) label value used is opaque.

EDIT: Issue at https://github.com/harvester/harvester/issues/7467.