### PR TITLE
feat: add enable tpm

### DIFF
--- a/harvester/create.go
+++ b/harvester/create.go
@@ -93,6 +93,12 @@ func (d *Driver) Create() error {
 	if err != nil {
 		return err
 	}
+
+	// tpm
+	if d.EnableTPM {
+		vmBuilder = vmBuilder.TPM()
+	}
+
 	// vm
 	vm, err := vmBuilder.VM()
 	if err != nil {

--- a/harvester/flags.go
+++ b/harvester/flags.go
@@ -168,6 +168,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "harvester-isolate-emulator-thread",
 			Usage:  "enable vm isolatated emulator thread",
 		},
+		mcnflag.BoolFlag{
+			EnvVar: "HARVESTER_ENABLE_TPM",
+			Name:   "harvester-enable-tpm",
+			Usage:  "enable vm TPM",
+		},
 	}
 }
 
@@ -264,6 +269,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.CPUPinning = flags.Bool("harvester-cpu-pinning")
 	d.IsolateEmulatorThread = flags.Bool("harvester-isolate-emulator-thread")
 
+	d.EnableTPM = flags.Bool("harvester-enable-tpm")
 	return d.checkConfig()
 }
 

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -78,6 +78,8 @@ type Driver struct {
 
 	CPUPinning            bool
 	IsolateEmulatorThread bool
+
+	EnableTPM bool
 }
 
 func NewDriver(hostName, storePath string) *Driver {


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/7365

## Test steps
1. Build docker-machine-driver-harvester with this patch(i.e. PR).
2. Import harvester cluster to rancher (i.e. `cluster-registration-url`).
3. Go to rancher UI, deactivate harvester node driver.
4. Use a http server to host artifacts in step 1. Change `harvester` node driver URL to it.
5. In rancher container, delete harvester dynamic schema 
   ```sh
   kubectl delete dynamicschemas.management.cattle.io/harvesterconfig
   ```
6. Remove `harvester` node driver status to trigger reload.
7. In rancher container, apply the following yaml files to deploy rke2 guest cluster to harvester. (make sure you fill in all fields start with `<YOUR_...` in the yaml examples.)
   - harvesterconfig.yaml
   ```yaml
    apiVersion: rke-machine-config.cattle.io/v1
    enableTpm: true
    diskInfo: '{"disks":[{"imageName":"default/<YOUR_IMAGE_UNDER_DEFAULT_NS>","bootOrder":1,"size":40}]}'
    kind: HarvesterConfig
    memorySize: "12"
    metadata:
      name: test
      namespace: fleet-default
    networkInfo: '{"interfaces":[{"networkName":"default/<YOUR_VM_NERWORK_UNDER_DEFAULT_NS>","macAddress":""}]}'
    sshPort: "22"
    sshUser: ubuntu
    userData: I2Nsb3VkLWNvbmZpZwpwYWNrYWdlX3VwZGF0ZTogdHJ1ZQpwYWNrYWdlczoKICAtIHFlbXUtZ3Vlc3QtYWdlbnQKcnVuY21kOgogIC0gLSBzeXN0ZW1jdGwKICAgIC0gZW5hYmxlCiAgICAtICctLW5vdycKICAgIC0gcWVtdS1ndWVzdC1hZ2VudC5zZXJ2aWNlCg==
    vmNamespace: default
   ```
   - cluster.yaml
   ```yaml
   apiVersion: provisioning.cattle.io/v1
    kind: Cluster
    metadata:
      name: foobar
      namespace: fleet-default
    spec:
      cloudCredentialSecretName: cattle-global-data:<YOUR_CLOUD_CREDENTIAL_SECRET_NAME>
      kubernetesVersion: v1.30.5+rke2r1
      rkeConfig:
        etcd:
          disableSnapshots: false
          snapshotRetention: 5
          snapshotScheduleCron: 0 */5 * * *
        machineGlobalConfig:
          cni: calico
          disable-kube-proxy: false
          etcd-expose-metrics: false
        machinePools:
          - name: pool1
            etcdRole: true
            controlPlaneRole: true
            workerRole: true
            quantity: 1
            unhealthyNodeTimeout: 0m
            machineConfigRef:
              kind: HarvesterConfig
              name: test
            drainBeforeDelete: true
            labels: {}
        machineSelectorConfig:
          - config:
              cloud-provider-name: harvester
              protect-kernel-defaults: false
        upgradeStrategy:
          controlPlaneConcurrency: '1'
          controlPlaneDrainOptions:
            deleteEmptyDirData: true
            disableEviction: false
            enabled: false
            force: false
            gracePeriod: -1
            ignoreDaemonSets: true
            skipWaitForDeleteTimeoutSeconds: 0
            timeout: 120
          workerConcurrency: '1'
          workerDrainOptions:
            deleteEmptyDirData: true
            disableEviction: false
            enabled: false
            force: false
            gracePeriod: -1
            ignoreDaemonSets: true
            skipWaitForDeleteTimeoutSeconds: 0
            timeout: 120
   ```
8. Go to harvester UI, navigate to Virtual Machines page, check the vm have the following attribute.
   ```yaml
    tpm: {}
   ```
  <img width="1304" alt="Screenshot 2025-02-17 at 3 38 56 PM" src="https://github.com/user-attachments/assets/2bd658bf-4237-4fed-a476-6d31117a72c7" />
