### PR TITLE
Update go.mod to fix several dependency errors

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
@@ -8,7 +8,7 @@ RUN zypper -n rm container-suseconnect && \
 
 ## install golangci-lint
 RUN if [ "${ARCH}" = "amd64" ]; then \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.8; \
     fi
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/docker-machine-driver-harvester
 
-go 1.23.4
+go 1.24.2
 
 replace (
 	github.com/docker/docker => github.com/moby/moby v1.4.2-0.20170731201646-1009e6a40b29 // oras dep requires a replace is set
@@ -17,10 +17,20 @@ replace (
 	k8s.io/apimachinery => k8s.io/apimachinery v0.30.3
 	k8s.io/apiserver => k8s.io/apiserver v0.30.3
 	k8s.io/client-go => k8s.io/client-go v0.30.3
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.30.3
 	k8s.io/component-base => k8s.io/component-base v0.30.3
+	k8s.io/cri-api => k8s.io/cri-api v0.30.3
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.30.3
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.30.3
+	k8s.io/endpointslice => k8s.io/endpointslice v0.30.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.30.3
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.30.3
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.30.3
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.30.3
 	k8s.io/kubernetes => k8s.io/kubernetes v1.30.3
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.30.3
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.30.3
 
 	kubevirt.io/api => github.com/kubevirt/api v1.3.0
 	kubevirt.io/client-go => github.com/kubevirt/client-go v1.3.0
@@ -30,9 +40,9 @@ replace (
 )
 
 require (
+	dario.cat/mergo v1.0.2
 	github.com/ghodss/yaml v1.0.0
 	github.com/harvester/harvester v1.3.0
-	github.com/imdario/mergo v0.3.16
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0
 	github.com/rancher/machine v0.15.0-rancher99
 	github.com/rancher/wrangler v1.1.2
@@ -82,6 +92,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/harvester/go-common v0.0.0-20240627083535-c1208a490f89 // indirect
 	github.com/iancoleman/orderedmap v0.2.0 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -594,6 +594,8 @@ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoIS
 cloud.google.com/go/workflows v1.8.0/go.mod h1:ysGhmEajwZxGn1OhGOGKsTXc5PyxOc0vfKf5Af+to4M=
 cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT3ujaO/WwSA=
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
+dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 emperror.dev/errors v0.8.1 h1:UavXZ5cSX/4u9iyvH6aDcuGkVjeexUGJ7Ij7G4VfQT0=
 emperror.dev/errors v0.8.1/go.mod h1:YcRvLPh626Ubn2xqtoprejnA5nFha+TJ+2vew48kWuE=

--- a/harvester/cloudinit.go
+++ b/harvester/cloudinit.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"dario.cat/mergo"
 	"github.com/ghodss/yaml"
 	"github.com/harvester/harvester/pkg/builder"
-	"github.com/imdario/mergo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )


### PR DESCRIPTION
- Update go version
- Update dario.cat/mergo (see https://github.com/darccio/mergo/releases/tag/v1.0.0)
- Fix errors like `go: k8s.io/cloud-provider@v0.0.0: invalid version: unknown revision v0.0.0`

#### Problem:
My Golang IDE is not able to resolve the module dependencies because of several errors. Because of that code navigation does not work and the IDE is spammed with error messages.

```
go: k8s.io/cloud-provider@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/cri-api@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/csi-translation-lib@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/dynamic-resource-allocation@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/endpointslice@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/kube-controller-manager@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/kube-proxy@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/kube-scheduler@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/legacy-cloud-providers@v0.0.0: invalid version: unknown revision v0.0.0
go: k8s.io/sample-apiserver@v0.0.0: invalid version: unknown revision v0.0.0
```
```
...
go: github.com/imdario/mergo@v1.0.2 found: parsing go.mod:
	module declares its path as: dario.cat/mergo
	        but was required as: github.com/imdario/mergo
go: github.com/imdario/mergo@upgrade (v1.0.2) requires github.com/imdario/mergo@v1.0.2: parsing go.mod:
	module declares its path as: dario.cat/mergo
	        but was required as: github.com/imdario/mergo
```

#### Solution:
Update go.mod.
