### PR TITLE
HostDeviceInfo support for various devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG MK_GOLANGCI_LINT_IMAGE
 ARG MK_PACKAGE_BASE registry.suse.com/bci/bci-base:16.0
 FROM ${MK_GOLANGCI_LINT_IMAGE} AS golangci-lint
 
-FROM golang:1.25-bookworm AS buildenv
+FROM golang:1.26-trixie AS buildenv
 ENV GOTOOLCHAIN=auto
 
 COPY --from=golangci-lint /usr/bin/golangci-lint /usr/local/bin/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ MK_CODECOV_TOKEN    ?=
 MK_DOCKER_PROGRESS  ?= plain
 
 MK_CODECOV_SECRET_ARG  := --secret id=codecov_token_$(MK_REPO_ID),env=MK_CODECOV_TOKEN --no-cache-filter=test
-MK_GOLANGCI_LINT_IMAGE := golangci/golangci-lint:v2.8.0-alpine@sha256:1194f3bfcbaeeb92d8d159fdfbe2a79d18ec0a222d9d984b1438906bca416b51
+MK_GOLANGCI_LINT_IMAGE := golangci/golangci-lint:v2.12.2-alpine@sha256:91b27804074a0bacea298707f016911e60cf0cdbc6c7bf5ccacb5f0606d18d60
 MK_PACKAGE_BASE        := registry.suse.com/bci/bci-base:16.0
 
 DOCKER_BUILD := \

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/harvester/docker-machine-driver-harvester
 
-go 1.25.11
+go 1.26
 
 replace (
 	github.com/google/gnostic-models => github.com/google/gnostic-models v0.6.9
+
+	github.com/harvester/harvester => github.com/harvester/harvester v0.0.0-20260325065442-726ea76ce461
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20250828140533-07a90f09a491

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w7
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/harvester/go-common v0.0.0-20260119194217-0f17176ce67e h1:0oo0OL30xJJ5uxu3RAFDvAGAzBT4VlKUiCA2yvOwHR4=
 github.com/harvester/go-common v0.0.0-20260119194217-0f17176ce67e/go.mod h1:r0hTaF8ZSSJEN7slrEzeJ80H66MPy+xFv3aScrxhLGI=
-github.com/harvester/harvester v1.8.0 h1:jOb1Kzu5TlAZ+QT6XlAPftyppOrdEZL1UfhDUn2ix4s=
-github.com/harvester/harvester v1.8.0/go.mod h1:1vlg1+mB8OHb9Meu+kMVOO/sG9130RE6+y3V1u1TXk4=
+github.com/harvester/harvester v0.0.0-20260325065442-726ea76ce461 h1:jNN78SCXVVX5rCUUMH89AYhqh4XW0qMU3C5r1+HZnPs=
+github.com/harvester/harvester v0.0.0-20260325065442-726ea76ce461/go.mod h1:1vlg1+mB8OHb9Meu+kMVOO/sG9130RE6+y3V1u1TXk4=
 github.com/harvester/harvester-network-controller v1.6.0-rc3 h1:lHpsxalwOboV5UaBL7T/XcV3Ib86VioyEju2J11/kUk=
 github.com/harvester/harvester-network-controller v1.6.0-rc3/go.mod h1:j+tWQZTf5aIg+rcvv4atUIu7LB7rfKtFfOfIv1MxcIs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/harvester/create.go
+++ b/harvester/create.go
@@ -360,8 +360,8 @@ func (d *Driver) ConfigureVGPU(vmBuilder *builder.VMBuilder) *builder.VMBuilder 
 // Configure host devices (USB, PCI, etc)
 func (d *Driver) ConfigureHostDevices(vmBuilder *builder.VMBuilder) *builder.VMBuilder {
 	if d.HostDeviceInfo != nil {
-		for _, d := range d.HostDeviceInfo.HostDeviceRequests {
-			vmBuilder.AddHostDevice(d.Name, d.DeviceName, "")
+		for _, d := range d.HostDeviceInfo.HostDevices {
+			vmBuilder.AddHostDevice(d.Name, d.DeviceName, d.Tag)
 		}
 	}
 	return vmBuilder

--- a/harvester/create.go
+++ b/harvester/create.go
@@ -113,6 +113,7 @@ func (d *Driver) Create() error {
 
 	// add vGPU info
 	vmBuilder = d.ConfigureVGPU(vmBuilder)
+	vmBuilder = d.ConfigureHostDevices(vmBuilder)
 	// disks
 	vmBuilder, err = d.Disks(vmBuilder)
 	if err != nil {
@@ -352,6 +353,16 @@ func (d *Driver) ConfigureVGPU(vmBuilder *builder.VMBuilder) *builder.VMBuilder 
 	for _, v := range d.VGPUInfo.VGPURequests {
 		// pass name, deviceName, tags(if any), and vGPUOptions if any
 		vmBuilder = vmBuilder.GPU(v.Name, v.DeviceName, "", nil)
+	}
+	return vmBuilder
+}
+
+// Configure host devices (USB, PCI, etc)
+func (d *Driver) ConfigureHostDevices(vmBuilder *builder.VMBuilder) *builder.VMBuilder {
+	if d.HostDeviceInfo != nil {
+		for _, d := range d.HostDeviceInfo.HostDeviceRequests {
+			vmBuilder.AddHostDevice(d.Name, d.DeviceName, "")
+		}
 	}
 	return vmBuilder
 }

--- a/harvester/flags.go
+++ b/harvester/flags.go
@@ -164,6 +164,24 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "harvester-vgpu-info",
 			Usage:  "harvester-vgpu-info",
 		},
+		mcnflag.StringFlag{
+			EnvVar: "HARVESTER_HOST_DEVICE_INFO",
+			Name:   "harvester-host-device-info",
+			Usage: `JSON string containing host device requests, e.g.:
+{
+  "hostDeviceRequests: [
+		{
+			"name": "qat",
+			"deviceName": "intel.com/qat""
+		},
+		{
+			"name": "tesla",
+			"deviceName": "nvidia.com/TU104GL_Tesla_T4"
+		}
+	]
+}
+`,
+		},
 		mcnflag.BoolFlag{
 			EnvVar: "HARVESTER_CPU_PINNING",
 			Name:   "harvester-cpu-pinning",
@@ -287,6 +305,15 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 			return err
 		}
 		d.VGPUInfo = vGPUInfo
+	}
+
+	hostDeviceInfoString := flags.String("harvester-host-device-info")
+	if hostDeviceInfoString != "" {
+		hdi, err := parseHostDeviceInfo(hostDeviceInfoString)
+		if err != nil {
+			return err
+		}
+		d.HostDeviceInfo = hdi
 	}
 
 	d.CPUPinning = flags.Bool("harvester-cpu-pinning")

--- a/harvester/harvester.go
+++ b/harvester/harvester.go
@@ -76,6 +76,7 @@ type Driver struct {
 	EnableEFI        bool
 	EnableSecureBoot bool
 	VGPUInfo         *VGPUInfo
+	HostDeviceInfo   *HostDeviceInfo
 
 	CPUPinning            bool
 	IsolateEmulatorThread bool

--- a/harvester/pcidevice.go
+++ b/harvester/pcidevice.go
@@ -1,0 +1,24 @@
+package harvester
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type HostDeviceInfo struct {
+	HostDeviceRequests []HostDeviceRequest `json:"hostDeviceRequests"`
+}
+
+type HostDeviceRequest struct {
+	Name       string `json:"name"`
+	DeviceName string `json:"deviceName"`
+}
+
+func parseHostDeviceInfo(info string) (*HostDeviceInfo, error) {
+	hdi := &HostDeviceInfo{}
+
+	if err := json.Unmarshal([]byte(info), hdi); err != nil {
+		return nil, fmt.Errorf("error unmarshalling host device information string: %w", err)
+	}
+	return hdi, nil
+}

--- a/harvester/pcidevice.go
+++ b/harvester/pcidevice.go
@@ -3,15 +3,12 @@ package harvester
 import (
 	"encoding/json"
 	"fmt"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 type HostDeviceInfo struct {
-	HostDeviceRequests []HostDeviceRequest `json:"hostDeviceRequests"`
-}
-
-type HostDeviceRequest struct {
-	Name       string `json:"name"`
-	DeviceName string `json:"deviceName"`
+	HostDevices []kubevirtv1.HostDevice `json:"hostDevices"`
 }
 
 func parseHostDeviceInfo(info string) (*HostDeviceInfo, error) {

--- a/harvester/pcidevice_test.go
+++ b/harvester/pcidevice_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 type testcase struct {
@@ -22,16 +23,16 @@ func Test_parseHostDeviceInfo(t *testing.T) {
 		},
 		{
 			description: "non-empty no device info",
-			input:       `{"hostDeviceRequests":[]}`,
+			input:       `{"hostDevices":[]}`,
 			expectation: &HostDeviceInfo{
-				HostDeviceRequests: []HostDeviceRequest{},
+				HostDevices: []kubevirtv1.HostDevice{},
 			},
 		},
 		{
 			description: "single device info",
-			input:       `{"hostDeviceRequests":[{"name":"qat","deviceName":"intel.com/qat"}]}`,
+			input:       `{"hostDevices":[{"name":"qat","deviceName":"intel.com/qat"}]}`,
 			expectation: &HostDeviceInfo{
-				HostDeviceRequests: []HostDeviceRequest{
+				HostDevices: []kubevirtv1.HostDevice{
 					{
 						Name:       "qat",
 						DeviceName: "intel.com/qat",

--- a/harvester/pcidevice_test.go
+++ b/harvester/pcidevice_test.go
@@ -1,0 +1,51 @@
+package harvester
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testcase struct {
+	description string
+	input       string
+	expectation *HostDeviceInfo
+}
+
+func Test_parseHostDeviceInfo(t *testing.T) {
+	testcases := []testcase{
+		{
+			description: "empty JSON input",
+			input:       `{}`,
+			expectation: &HostDeviceInfo{},
+		},
+		{
+			description: "non-empty no device info",
+			input:       `{"hostDeviceRequests":[]}`,
+			expectation: &HostDeviceInfo{
+				HostDeviceRequests: []HostDeviceRequest{},
+			},
+		},
+		{
+			description: "single device info",
+			input:       `{"hostDeviceRequests":[{"name":"qat","deviceName":"intel.com/qat"}]}`,
+			expectation: &HostDeviceInfo{
+				HostDeviceRequests: []HostDeviceRequest{
+					{
+						Name:       "qat",
+						DeviceName: "intel.com/qat",
+					},
+				},
+			},
+		},
+	}
+
+	assert := require.New(t)
+
+	for i, tc := range testcases {
+		v, err := parseHostDeviceInfo(tc.input)
+		assert.NoError(err)
+		assert.Equal(v, tc.expectation, fmt.Sprintf("failed %d: %s: expected request to match predefined objectg", i, tc.description))
+	}
+}


### PR DESCRIPTION
Add HostDeviceInfo struct and related command line flag to the Docker machine driver. This enables the driver to add various host devices (USB, PCI, etc) to a VM.

#### Problem:

Rancher Terraform provider can not attach host devices other than vGPUs to VMs.
This is due to the fact that it uses the `.spec.domain.devices.gpus` fiel in the VM instance template.

#### Solution:

Add an analogue mechanism for adding host devices in general using the `.spec.domain.devices.hostDevices` field in the VM instance spec.
This works for PCI devices other than GPUs as well as USB devices.

#### Related Issue(s):

harvester/harvester#10764

#### Test plan:

TBD.

#### Additional documentation or context
